### PR TITLE
Fixed computer type

### DIFF
--- a/packages/common/computer.d.ts
+++ b/packages/common/computer.d.ts
@@ -6,7 +6,7 @@
  * @noResolution
  */
 declare module "computer" {
-    const computer: OC.ComponentApi;
+    const computer: OC.ComputerApi;
     export = computer;
 }
 


### PR DESCRIPTION
`import * as computer from "computer"` gives `computer` variable with wrong `OC.ComponentApi` type.
Changed it's type to `OC.ComputerApi`